### PR TITLE
fix(spec-specs): require and use blockenv for state tracking

### DIFF
--- a/src/ethereum/forks/amsterdam/fork.py
+++ b/src/ethereum/forks/amsterdam/fork.py
@@ -921,13 +921,13 @@ def process_transaction(
     effective_gas_fee = tx.gas * effective_gas_price
 
     gas = tx.gas - intrinsic_gas
-    increment_nonce(block_env.state, sender)
+    increment_nonce(block_env.state, sender, block_env)
 
     sender_balance_after_gas_fee = (
         Uint(sender_account.balance) - effective_gas_fee - blob_gas_fee
     )
     set_account_balance(
-        block_env.state, sender, U256(sender_balance_after_gas_fee)
+        block_env.state, sender, U256(sender_balance_after_gas_fee), block_env
     )
 
     access_list_addresses = set()
@@ -993,7 +993,9 @@ def process_transaction(
     sender_balance_after_refund = get_account(
         block_env.state, sender
     ).balance + U256(gas_refund_amount)
-    set_account_balance(block_env.state, sender, sender_balance_after_refund)
+    set_account_balance(
+        block_env.state, sender, sender_balance_after_refund, block_env
+    )
 
     # transfer miner fees
     coinbase_balance_after_mining_fee = get_account(
@@ -1005,6 +1007,7 @@ def process_transaction(
         block_env.state,
         block_env.coinbase,
         coinbase_balance_after_mining_fee,
+        block_env,
     )
 
     if coinbase_balance_after_mining_fee == 0 and account_exists_and_is_empty(

--- a/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
+++ b/src/ethereum/forks/amsterdam/vm/eoa_delegation.py
@@ -255,9 +255,9 @@ def set_delegation(message: Message) -> U256:
             code_to_set = b""
         else:
             code_to_set = EOA_DELEGATION_MARKER + auth.address
-        set_code(state, authority, code_to_set)
+        set_code(state, authority, code_to_set, message.block_env)
 
-        increment_nonce(state, authority)
+        increment_nonce(state, authority, message.block_env)
 
     if message.code_address is None:
         raise InvalidBlock("Invalid type 4 transaction: no target")

--- a/src/ethereum/forks/amsterdam/vm/instructions/storage.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/storage.py
@@ -100,6 +100,11 @@ def sstore(evm: Evm) -> None:
         state, evm.message.current_target, key
     )
     current_value = get_storage(state, evm.message.current_target, key)
+    track_storage_read(
+        evm.message.block_env,
+        evm.message.current_target,
+        key,
+    )
 
     # GAS
     gas_cost = Uint(0)
@@ -123,18 +128,6 @@ def sstore(evm: Evm) -> None:
 
     if is_cold_access:
         evm.accessed_storage_keys.add((evm.message.current_target, key))
-
-    track_storage_read(
-        evm.message.block_env,
-        evm.message.current_target,
-        key,
-    )
-    track_storage_write(
-        evm.message.block_env,
-        evm.message.current_target,
-        key,
-        new_value,
-    )
 
     charge_gas(evm, gas_cost)
     if evm.message.is_static:
@@ -163,6 +156,12 @@ def sstore(evm: Evm) -> None:
 
     # OPERATION
     set_storage(state, evm.message.current_target, key, new_value)
+    track_storage_write(
+        evm.message.block_env,
+        evm.message.current_target,
+        key,
+        new_value,
+    )
 
     # PROGRAM COUNTER
     evm.pc += Uint(1)

--- a/src/ethereum/forks/amsterdam/vm/instructions/system.py
+++ b/src/ethereum/forks/amsterdam/vm/instructions/system.py
@@ -122,6 +122,7 @@ def generic_create(
         increment_nonce(
             state,
             evm.message.current_target,
+            evm.message.block_env,
         )
         push(evm.stack, U256(0))
         return
@@ -129,6 +130,7 @@ def generic_create(
     increment_nonce(
         state,
         evm.message.current_target,
+        evm.message.block_env,
     )
 
     child_message = Message(
@@ -613,6 +615,7 @@ def selfdestruct(evm: Evm) -> None:
         originator,
         beneficiary,
         originator_balance,
+        evm.message.block_env,
     )
 
     # register account for deletion only if it was created
@@ -624,6 +627,7 @@ def selfdestruct(evm: Evm) -> None:
             evm.message.block_env.state,
             originator,
             U256(0),
+            evm.message.block_env,
         )
         evm.accounts_to_delete.add(originator)
 

--- a/src/ethereum/forks/amsterdam/vm/interpreter.py
+++ b/src/ethereum/forks/amsterdam/vm/interpreter.py
@@ -205,7 +205,7 @@ def process_create_message(message: Message) -> Evm:
     # added to SELFDESTRUCT by EIP-6780.
     mark_account_created(state, message.current_target)
 
-    increment_nonce(state, message.current_target)
+    increment_nonce(state, message.current_target, message.block_env)
     evm = process_message(message)
     if not evm.error:
         contract_code = evm.output
@@ -223,7 +223,9 @@ def process_create_message(message: Message) -> Evm:
             evm.output = b""
             evm.error = error
         else:
-            set_code(state, message.current_target, contract_code)
+            set_code(
+                state, message.current_target, contract_code, message.block_env
+            )
             commit_transaction(state, transient_storage)
     else:
         rollback_transaction(state, transient_storage)

--- a/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
+++ b/src/ethereum_spec_tools/evm_tools/t8n/__init__.py
@@ -253,9 +253,7 @@ class T8N(Load):
 
     def _run_blockchain_test(self, block_env: Any, block_output: Any) -> None:
         if self.fork.is_after_fork("amsterdam"):
-            self.fork.set_block_access_index(
-                block_env.state.change_tracker, Uint(0)
-            )
+            self.fork.set_block_access_index(block_env, Uint(0))
         if self.fork.is_after_fork("prague"):
             self.fork.process_unchecked_system_transaction(
                 block_env=block_env,
@@ -292,7 +290,6 @@ class T8N(Load):
                 )
 
         if self.fork.is_after_fork("amsterdam"):
-            assert block_env.state.change_tracker is not None
             num_transactions = ulen(
                 [
                     tx_idx
@@ -303,9 +300,7 @@ class T8N(Load):
 
             # post-execution use n + 1
             post_execution_index = num_transactions + Uint(1)
-            self.fork.set_block_access_index(
-                block_env.state.change_tracker, post_execution_index
-            )
+            self.fork.set_block_access_index(block_env, post_execution_index)
 
         if not self.fork.is_after_fork("paris"):
             if self.options.state_reward is None:
@@ -325,7 +320,7 @@ class T8N(Load):
 
         if self.fork.is_after_fork("amsterdam"):
             block_output.block_access_list = self.fork.build_block_access_list(
-                block_env.state.change_tracker.block_access_list_builder
+                block_env.change_tracker.block_access_list_builder
             )
 
     def run_blockchain_test(self) -> None:


### PR DESCRIPTION
We were missing passing in the `block_env` in many places. I think this should be required and a simple lint check showed me everywhere we needed to update it. These changes have all BAL tests passing 👌🏼

Also changed:

- Track read when we read
- Track write when we write

This PR also fixes the remaining lint issues with `nerolation/larger-refactoring`